### PR TITLE
fix: mark/fixing-run-sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To integrate Secoda MCP with Cursor, add the following configuration to your `~/
 ```json
 {
     "mcpServers": {
-        "secoda-mcp": {
+        "secoda_mcp": {
             "command": "python",
             "args": [
                 "/path/to/secoda-mcp/server.py"

--- a/server.py
+++ b/server.py
@@ -1,4 +1,5 @@
 import os
+import typing
 
 import requests
 from fastmcp import FastMCP
@@ -43,9 +44,9 @@ def call_tool(tool_name: str, args: dict):
 
 
 @mcp.tool()
-def run_sql(query: str) -> str:
+def run_sql(query: str, integration_id: typing.Optional[str] = None) -> str:
     """Run a SQL query on the database."""
-    return call_tool("run_sql", {"query": query})
+    return call_tool("run_sql", {"query": query, "integration_id": integration_id})
 
 
 @mcp.tool()


### PR DESCRIPTION
Run SQL tool needs an integration id key set, even if its `None` / `""`